### PR TITLE
Fix title of papers

### DIFF
--- a/_papers/2008-11-22-twisted.md
+++ b/_papers/2008-11-22-twisted.md
@@ -1,9 +1,7 @@
 ---
-title:
-- Very twisted stable maps
+title: Very twisted stable maps
 
-journal:
- - Communications in Analysis and Geometry, Volume 18, Number 4. (2010)
+journal: Communications in Analysis and Geometry, Volume 18, Number 4. (2010)
 
 authors:
 - chen

--- a/_papers/2010-12-12-unific.md
+++ b/_papers/2010-12-12-unific.md
@@ -1,11 +1,9 @@
 ---
-title:
-- A unification of permutation patterns related to Schubert varieties
+title: A unification of permutation patterns related to Schubert varieties
 
-journal:
- - Pure Mathematics and Applications, Volume 22 (2011), Issue No. 2 
+journal: Pure Mathematics and Applications, Volume 22 (2011), Issue No. 2
 
-authors: 
+authors:
 - ulfarsson
 
 projects:

--- a/_papers/2011-06-17-wordgraphs.md
+++ b/_papers/2011-06-17-wordgraphs.md
@@ -1,9 +1,7 @@
 ---
-title:
-- Word-representability of line graphs
+title: Word-representability of line graphs
 
-journal:
- - Open Journal of Discrete Mathematics, Volume 1, Number 2 (2011) 
+journal: Open Journal of Discrete Mathematics, Volume 1, Number 2 (2011)
 
 authors:
 - kitaev

--- a/_papers/2011-12-17-w3s.md
+++ b/_papers/2011-12-17-w3s.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Describing West-3-stack-sortable permutations with permutation patterns
+title: Describing West-3-stack-sortable permutations with permutation patterns
 
-journal:
- - Séminaire Lotharingien de Combinatoire, Volume 67 (2012), Article B67d 
+journal: Séminaire Lotharingien de Combinatoire, Volume 67 (2012), Article B67d
 
-authors: 
+authors:
 - ulfarsson
 
 projects:

--- a/_papers/2012-01-01-refinvs.md
+++ b/_papers/2012-01-01-refinvs.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Refined inversion statistics on permutations
+title: Refined inversion statistics on permutations
 
-journal:
- - Electronic Journal of Combinatorics, Volume 19 (2012)
+journal: Electronic Journal of Combinatorics, Volume 19 (2012)
 
-authors: 
+authors:
 - sack
 - ulfarsson
 

--- a/_papers/2013-03-14-lci.md
+++ b/_papers/2013-03-14-lci.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Which Schubert varieties are local complete intersections?
+title: Which Schubert varieties are local complete intersections?
 
-journal:
- - Proceedings of the London Mathematical Society, Volume 107, Issue 5 (2013), Pages 1004–1052
+journal: Proceedings of the London Mathematical Society, Volume 107, Issue 5 (2013), Pages 1004–1052
 
-authors: 
+authors:
 - ulfarsson
 - woo
 

--- a/_papers/2013-11-21-maps.md
+++ b/_papers/2013-11-21-maps.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Restricted non-separable planar maps and some pattern avoiding permutations
+title: Restricted non-separable planar maps and some pattern avoiding permutations
 
-journal:
- - Discrete Applied Mathematics, Volume 161, Issues 16–17, (2013), Pages 2514-2526
+journal: Discrete Applied Mathematics, Volume 161, Issues 16–17, (2013), Pages 2514-2526
 
-authors: 
+authors:
 - kitaev
 - salimov
 - severs

--- a/_papers/2014-09-10-shlemma.md
+++ b/_papers/2014-09-10-shlemma.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Wilf-classification of mesh patterns of short length
+title: Wilf-classification of mesh patterns of short length
 
-journal:
- - Electronic Journal of Combinatorics, Volume 22 (2015)
+journal: Electronic Journal of Combinatorics, Volume 22 (2015)
 
-authors: 
+authors:
 - hilmarsson
 - jonsdottir
 - sigurdardottir

--- a/_papers/2014-12-04-sshlemma.md
+++ b/_papers/2014-12-04-sshlemma.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Coincidence among families of mesh patterns
+title: Coincidence among families of mesh patterns
 
-journal:
-- The Australasian Journal of Combinatorics 2015, Volume 63 Part 1 (2015)
+journal: The Australasian Journal of Combinatorics 2015, Volume 63 Part 1 (2015)
 
-authors: 
+authors:
 - claesson
 - ulfarsson
 - tenner

--- a/_papers/2015-12-17-sortpreim.md
+++ b/_papers/2015-12-17-sortpreim.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Sorting and preimages of pattern classes
+title: Sorting and preimages of pattern classes
 
-journal:
- - In preparation
+journal: In preparation
 
-authors: 
+authors:
 - claesson
 - ulfarsson
 

--- a/_papers/2017-02-14-covinc.md
+++ b/_papers/2017-02-14-covinc.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Enumerations of Permutations Simultaneously Avoiding a Vincular and a Covincular Pattern of Length 3
+title: Enumerations of Permutations Simultaneously Avoiding a Vincular and a Covincular Pattern of Length 3
 
-journal:
- - Journal of Integer Sequences, Volume 20 (2017), Article 17.7.6
+journal: Journal of Integer Sequences, Volume 20 (2017), Article 17.7.6
 
-authors: 
+authors:
 - bean
 - claesson
 - ulfarsson

--- a/_papers/2017-09-01-cognitive.md
+++ b/_papers/2017-09-01-cognitive.md
@@ -1,9 +1,7 @@
 ---
-title:
-- Cognitive workload classification using cardiovascular measures and dynamic features
+title: Cognitive workload classification using cardiovascular measures and dynamic features
 
-journal:
- - IEEE 8th International Conference on Cognitive Infocommunications
+journal: IEEE 8th International Conference on Cognitive Infocommunications
 
 authors:
 - bean

--- a/_papers/2018-12-11-struct.md
+++ b/_papers/2018-12-11-struct.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Automatic discovery of structural rules of permutation classes
+title: Automatic discovery of structural rules of permutation classes
 
-journal:
- - Mathematics of Computation, Volume 88, Number 318, July 2019, Pages 1967–1990
+journal: Mathematics of Computation, Volume 88, Number 318, July 2019, Pages 1967–1990
 
-authors: 
+authors:
 - bean
 - gudmundsson
 - ulfarsson

--- a/_papers/2018-2-9-dom.md
+++ b/_papers/2018-2-9-dom.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Equivalence classes of mesh patterns with a dominating pattern
+title: Equivalence classes of mesh patterns with a dominating pattern
 
-journal:
- - Discrete Mathematics & Theoretical Computer Science, February 9, 2018, Vol. 19 no. 2, Permutation Patterns 2016
+journal: Discrete Mathematics & Theoretical Computer Science, February 9, 2018, Vol. 19 no. 2, Permutation Patterns 2016
 
-authors: 
+authors:
 - tannock
 - ulfarsson
 

--- a/_papers/2019-01-10-occgraphs.md
+++ b/_papers/2019-01-10-occgraphs.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Occurrence graphs of patterns in permutations
+title: Occurrence graphs of patterns in permutations
 
-journal:
- - To appear in Involve
+journal: To appear in Involve
 
-authors: 
+authors:
 - kristinsson
 - ulfarsson
 

--- a/_papers/2019-02-01-pattgons.md
+++ b/_papers/2019-02-01-pattgons.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Pattern avoiding permutations and independent sets in graphs
+title: Pattern avoiding permutations and independent sets in graphs
 
-journal:
- - Submitted
+journal: Submitted
 
-authors: 
+authors:
 - bean
 - tannock
 - ulfarsson

--- a/_papers/2019-02-02-biscpaper.md
+++ b/_papers/2019-02-02-biscpaper.md
@@ -1,11 +1,9 @@
 ---
-title:
-- 'BiSC: An algorithm for discovering generalized permutation patterns'
+title: 'BiSC: An algorithm for discovering generalized permutation patterns'
 
-journal:
- - In preparation
+journal: In preparation
 
-authors: 
+authors:
 - ulfarsson
 
 projects:
@@ -59,7 +57,7 @@ largest_bad_perms  = 8
 cpus               = 7
 
 A, B = examples_for_bisc( gr_num, ex_num, largest_good_perms, largest_bad_perms, cpus )
-    
+
 size_of_subdicts(A)
 ```
 
@@ -160,7 +158,7 @@ L               = largest_bad_perms
 stop_on_failure = False
 parallel        = True
 ncpus           = 7
-        
+
 patterns_suffice( SG ,L , B, stop_on_failure, parallel, ncpus )
 ```
 

--- a/_papers/2019-02-20-collatz.md
+++ b/_papers/2019-02-20-collatz.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Collatz meets Fibonacci
+title: Collatz meets Fibonacci
 
-journal:
- - Submitted
+journal: Submitted
 
-authors: 
+authors:
 - albert
 - gudmundsson
 - ulfarsson

--- a/_papers/2019-02-21-meshposet.md
+++ b/_papers/2019-02-21-meshposet.md
@@ -1,11 +1,9 @@
 ---
-title:
-- The poset of mesh patterns
+title: The poset of mesh patterns
 
-journal:
- - To appear in Discrete Mathematics
+journal: To appear in Discrete Mathematics
 
-authors: 
+authors:
 - smith
 - ulfarsson
 

--- a/_papers/2019-02-27-combex.md
+++ b/_papers/2019-02-27-combex.md
@@ -1,9 +1,7 @@
 ---
-title:
-- 'Combinatorial Exploration: An Algorithmic Framework for Enumeration'
+title: 'Combinatorial Exploration: An Algorithmic Framework for Enumeration'
 
-journal:
- - In preparation
+journal: In preparation
 
 authors:
 - albert

--- a/_papers/2019-03-03-shalg.md
+++ b/_papers/2019-03-03-shalg.md
@@ -1,11 +1,9 @@
 ---
-title:
-- Algorithmic coincidence classification of mesh patterns
+title: Algorithmic coincidence classification of mesh patterns
 
-journal:
- - In preparation
+journal: In preparation
 
-authors: 
+authors:
 - gudmundsson
 - tmagnusson
 - ulfarsson


### PR DESCRIPTION
I don't know why the the `title` and `journal` fields of papers were given as list. This is annoying since the page title is then something like
```
[“Algorithmic coincidence classification of mesh patterns”] | Permuta Triangle
``` 
instead of
```
Algorithmic coincidence classification of mesh patterns | Permuta Triangle
``` 

I've fixed it, just merge if you agree.